### PR TITLE
feat: add read-mind-map tool (Markdown export)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ An MCP (Model Context Protocol) server for generating Xmind mind maps. This serv
 ## Features
 
 - Generate Xmind mind maps with hierarchical topic structures
-- Support for topic notes, labels, and markers
+- Support for topic notes, labels, markers, and relationships
 - Save mind maps to local files
+- **Read existing .xmind files and export an outline as Markdown**
 - Easy integration with Claude Desktop and other MCP clients
 
 ## Prerequisites
@@ -97,6 +98,22 @@ Parameters:
   - `children` (array, optional): Array of child topics
 - `relationships` (array, optional): Array of relationships between topics
 - `outputPath` (string, optional): Custom output path for the Xmind file. This overrides the environment variable if set.
+
+### read-mind-map
+
+Reads an existing `.xmind` file and exports it as a Markdown outline.
+
+Parameters:
+- `inputPath` (string): Path to the `.xmind` file
+- `style` (string, optional): Markdown style. Currently supports `A` (outline). (`B` reserved for future richer exports.)
+
+Example:
+```json
+{
+  "inputPath": "/path/to/file.xmind",
+  "style": "A"
+}
+```
 
 
 ## Example

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { exec } from 'child_process';
 import { createRequire } from 'module';
+import { readXmindToTree, treeToMarkdown } from './read.js';
 
 // Create a require function for ES modules
 const require = createRequire(import.meta.url);
@@ -59,8 +60,14 @@ const GenerateMindMapSchema = z.object({
   relationships: z.array(RelationshipSchema).optional().describe('Optional array of relationships between topics')
 });
 
+const ReadMindMapSchema = z.object({
+  inputPath: z.string().describe('Path to the .xmind file to read'),
+  style: z.enum(['A', 'B']).optional().describe('Markdown export style. A=outline titles only; B=include more details if available (future). Default A.')
+});
+
 type TopicData = z.infer<typeof TopicSchema>;
 type GenerateMindMapParams = z.infer<typeof GenerateMindMapSchema>;
+type ReadMindMapParams = z.infer<typeof ReadMindMapSchema>;
 
 
 
@@ -208,6 +215,28 @@ server.tool(
   }
 );
 
+
+// Register the read-mind-map tool (Markdown export)
+server.tool(
+  'read-mind-map',
+  ReadMindMapSchema.shape,
+  async (params: ReadMindMapParams) => {
+    try {
+      const tree = await readXmindToTree(params.inputPath);
+      // Currently style A only (outline). Style B can be added later when we preserve notes/labels.
+      const md = treeToMarkdown(tree);
+      return { content: [{ type: 'text', text: md }] };
+    } catch (error) {
+      return {
+        content: [{
+          type: 'text',
+          text: `Error reading mind map: ${error instanceof Error ? error.message : String(error)}`
+        }],
+        isError: true
+      };
+    }
+  }
+);
 
 
 

--- a/src/read.ts
+++ b/src/read.ts
@@ -1,0 +1,58 @@
+import * as fs from 'fs';
+import JSZip from 'jszip';
+
+export type TopicData = {
+  title: string;
+  children?: TopicData[];
+};
+
+function topicFromXmind(node: any): TopicData {
+  const t: TopicData = {
+    title: String(node?.title ?? '').trim()
+  };
+
+  const attached = node?.children?.attached;
+  if (Array.isArray(attached) && attached.length) {
+    t.children = attached.map(topicFromXmind);
+  }
+
+  return t;
+}
+
+export async function readXmindToTree(inputXmindPath: string): Promise<{ title: string; topics: TopicData[] }> {
+  const buf = fs.readFileSync(inputXmindPath);
+  const zip = await JSZip.loadAsync(buf);
+
+  const contentFile = zip.file('content.json');
+  if (!contentFile) throw new Error('Invalid .xmind: missing content.json');
+
+  const contentJson = await contentFile.async('string');
+  const doc = JSON.parse(contentJson);
+  if (!Array.isArray(doc) || !doc.length) throw new Error('Invalid content.json: expected array of sheets');
+
+  const sheet = doc[0];
+  const root = sheet?.rootTopic;
+  if (!root?.title) throw new Error('Invalid content.json: missing rootTopic.title');
+
+  const topics = Array.isArray(root?.children?.attached)
+    ? root.children.attached.map(topicFromXmind)
+    : [];
+
+  return { title: String(root.title), topics };
+}
+
+export function treeToMarkdown(tree: { title: string; topics: TopicData[] }): string {
+  const lines: string[] = [];
+  lines.push(`# ${tree.title}`);
+
+  const walk = (node: TopicData, depth: number) => {
+    const indent = '  '.repeat(Math.max(0, depth - 1));
+    lines.push(`${indent}- ${node.title}`);
+    if (node.children?.length) {
+      for (const c of node.children) walk(c, depth + 1);
+    }
+  };
+
+  for (const t of tree.topics) walk(t, 1);
+  return lines.join('\n');
+}


### PR DESCRIPTION
Adds a new MCP tool `read-mind-map` to read existing .xmind files and export a Markdown outline. Includes README updates and a small parser module.

- New tool: `read-mind-map` (inputPath, style=A)
- New module: src/read.ts
- Docs: README updated
